### PR TITLE
JACK

### DIFF
--- a/org.hydrogenmusic.Hydrogen.json
+++ b/org.hydrogenmusic.Hydrogen.json
@@ -142,7 +142,7 @@
       "buildsystem": "cmake-ninja",
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DWANT_JACK=0",
+        "-DWANT_JACK=1",
         "-DWANT_LASH=1",
         "-DWANT_PORTAUDIO=1",
         "-DWANT_PORTMIDI=1"


### PR DESCRIPTION
The JACK library is already built as its included as a
shared module, but the corresponding build option at
Hydrogen itself is currently disabled.

KDE Platform 5.15 is based on FreeDesktop 20.08, which
includes pipewire-jack replacement libraries by default.