### PR TITLE
Fix vamp x86_64 build failures by single-threading build

### DIFF
--- a/org.hydrogenmusic.Hydrogen.json
+++ b/org.hydrogenmusic.Hydrogen.json
@@ -95,6 +95,7 @@
     "shared-modules/linux-audio/liblo.json",
     {
       "name": "vamp-plugin-sdk",
+      "no-parallel-make": true,
       "sources": [
         {
           "type": "archive",


### PR DESCRIPTION
Seems to have worked for a month in zrythm without x86_64 build failures. It builds and runs here although I haven't tested beyond that.

Marked as draft since Ladspa's checksum changed, that should be fixed in shared-modules not copy pasted here. https://github.com/flathub/shared-modules/pull/184