### PR TITLE
Actually build release

### DIFF
--- a/org.hydrogenmusic.Hydrogen.json
+++ b/org.hydrogenmusic.Hydrogen.json
@@ -157,7 +157,7 @@
       "name": "hydrogen",
       "buildsystem": "cmake-ninja",
       "config-opts": [
-        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+        "-DWANT_DEBUG=OFF",
         "-DWANT_JACK=0",
         "-DWANT_LASH=1",
         "-DWANT_PORTAUDIO=1",


### PR DESCRIPTION
- because they couldn't use the standard way