### PR TITLE
fix compilation flags

### DIFF
--- a/org.hydrogenmusic.Hydrogen.json
+++ b/org.hydrogenmusic.Hydrogen.json
@@ -144,10 +144,17 @@
       "buildsystem": "cmake-ninja",
       "config-opts": [
         "-DWANT_DEBUG=OFF",
+        "-DWANT_ALSA=ON",
+        "-DWANT_PULSEAUDIO=ON",
         "-DWANT_JACK=ON",
+        "-DWANT_LADSPA=ON",
+        "-DWANT_LRDF=ON",
+        "-DWANT_OSC=ON",
         "-DWANT_LASH=ON",
         "-DWANT_PORTAUDIO=ON",
-        "-DWANT_PORTMIDI=ON"
+        "-DWANT_PORTMIDI=ON",
+        "-DWANT_RUBBERBAND=ON",
+        "-DWANT_LIBARCHIVE=ON"
       ],
       "build-options": {
         "env": [


### PR DESCRIPTION
Explicitly turning on desired compilation flags.

Some dependencies, like `liblrdf` and `rubberband`, are build as modules. But Hydrogen is compiled without their support.